### PR TITLE
Make device_id not required

### DIFF
--- a/push_notifications/api/__init__.py
+++ b/push_notifications/api/__init__.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+
+if "tastypie" in settings.INSTALLED_APPS:
+	# Tastypie resources are importable from the api package level (backwards compatibility)
+	from .tastypie import APNSDeviceResource, GCMDeviceResource, APNSDeviceAuthenticatedResource, GCMDeviceAuthenticatedResource
+
+	__all__ = [
+		"APNSDeviceResource",
+		"GCMDeviceResource",
+		"APNSDeviceAuthenticatedResource",
+		"GCMDeviceAuthenticatedResource"
+	]

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import
+
+from rest_framework import permissions
+from rest_framework.serializers import ModelSerializer, ValidationError
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.fields import IntegerField
+
+from push_notifications.models import APNSDevice, GCMDevice
+from push_notifications.fields import hex_re
+
+
+# Fields
+
+class HexIntegerField(IntegerField):
+	"""
+	Store an integer represented as a hex string of form "0x01".
+	"""
+
+	def to_internal_value(self, data):
+		data = int(data, 16)
+		return super(HexIntegerField, self).to_internal_value(data)
+
+	def to_representation(self, value):
+		return value
+
+
+# Serializers
+class DeviceSerializerMixin(ModelSerializer):
+	class Meta:
+		fields = ("name", "registration_id", "device_id", "active", "date_created")
+		read_only_fields = ("date_created", )
+
+
+class APNSDeviceSerializer(ModelSerializer):
+
+	class Meta(DeviceSerializerMixin.Meta):
+		model = APNSDevice
+
+	def validate_registration_id(self, value):
+		# iOS device tokens are 256-bit hexadecimal (64 characters)
+
+		if hex_re.match(value) is None or len(value) != 64:
+			raise ValidationError("Registration ID (device token) is invalid")
+
+		return value
+
+
+class GCMDeviceSerializer(ModelSerializer):
+	device_id = HexIntegerField(
+		help_text="ANDROID_ID / TelephonyManager.getDeviceId() (e.g: 0x01)",
+		style={'input_type': 'text'}
+	)
+
+	class Meta(DeviceSerializerMixin.Meta):
+		model = GCMDevice
+
+
+# Permissions
+class IsOwner(permissions.BasePermission):
+	def has_object_permission(self, request, view, obj):
+		# must be the owner to view the object
+		return obj.user == request.user
+
+
+# Mixins
+class DeviceViewSetMixin(object):
+	lookup_field = "registration_id"
+
+	def perform_create(self, serializer):
+		if self.request.user.is_authenticated():
+			serializer.save(user=self.request.user)
+
+
+class AuthorizedMixin(object):
+	permission_classes = (permissions.IsAuthenticated, IsOwner)
+
+	def get_queryset(self):
+		# filter all devices to only those belonging to the current user
+		return self.queryset.filter(user=self.request.user)
+
+
+# ViewSets
+class APNSDeviceViewSet(DeviceViewSetMixin, ModelViewSet):
+	queryset = APNSDevice.objects.all()
+	serializer_class = APNSDeviceSerializer
+
+
+class APNSDeviceAuthorizedViewSet(AuthorizedMixin, APNSDeviceViewSet):
+	pass
+
+
+class GCMDeviceViewSet(DeviceViewSetMixin, ModelViewSet):
+	queryset = GCMDevice.objects.all()
+	serializer_class = GCMDeviceSerializer
+
+
+class GCMDeviceAuthorizedViewSet(AuthorizedMixin, GCMDeviceViewSet):
+	pass

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -48,7 +48,8 @@ class APNSDeviceSerializer(ModelSerializer):
 class GCMDeviceSerializer(ModelSerializer):
 	device_id = HexIntegerField(
 		help_text="ANDROID_ID / TelephonyManager.getDeviceId() (e.g: 0x01)",
-		style={'input_type': 'text'}
+		style={'input_type': 'text'},
+		required=False
 	)
 
 	class Meta(DeviceSerializerMixin.Meta):

--- a/push_notifications/api/tastypie.py
+++ b/push_notifications/api/tastypie.py
@@ -1,7 +1,7 @@
 from tastypie.authorization import Authorization
 from tastypie.authentication import BasicAuthentication
 from tastypie.resources import ModelResource
-from .models import APNSDevice, GCMDevice
+from push_notifications.models import APNSDevice, GCMDevice
 
 
 class APNSDeviceResource(ModelResource):

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
 	name="django-push-notifications",
 	packages=[
 		"push_notifications",
+		"push_notifications/api",
 		"push_notifications/migrations",
 		"push_notifications/management",
 		"push_notifications/management/commands",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,3 +2,11 @@ from test_models import *
 from test_gcm_push_payload import *
 from test_apns_push_payload import *
 from test_management_commands import *
+
+# conditionally test rest_framework api if the DRF package is installed
+try:
+	import rest_framework
+except ImportError:
+	pass
+else:
+	from test_rest_framework import *

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,0 +1,36 @@
+import json
+import mock
+from django.test import TestCase
+from django.utils import timezone
+from push_notifications.models import GCMDevice, APNSDevice
+from tests.mock_responses import GCM_PLAIN_RESPONSE, GCM_MULTIPLE_JSON_RESPONSE
+from push_notifications.api.rest_framework import APNSDeviceSerializer, GCMDeviceSerializer
+
+class APNSDeviceSerializerTestCase(TestCase):
+    def test_validation(self):
+        # valid data - upper case
+        serializer = APNSDeviceSerializer(data={
+            "registration_id": "AEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAE",
+            "name": "Apple iPhone 6+",
+            "device_id": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+        })
+        self.assertTrue(serializer.is_valid())
+
+        # valid data - lower case
+        serializer = APNSDeviceSerializer(data={
+            "registration_id": "aeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeae",
+            "name": "Apple iPhone 6+",
+            "device_id": "ffffffffffffffffffffffffffffffff",
+        })
+        self.assertTrue(serializer.is_valid())
+
+        # invalid data - device_id, registration_id
+        serializer = APNSDeviceSerializer(data={
+            "registration_id": "invalid device token contains no hex",
+            "name": "Apple iPhone 6+",
+            "device_id": "ffffffffffffffffffffffffffffake",
+        })
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors["device_id"][0], '"ffffffffffffffffffffffffffffake" is not a valid UUID.')
+        self.assertEqual(serializer.errors["registration_id"][0], "Registration ID (device token) is invalid")
+


### PR DESCRIPTION
Just tested with some real GCM credentials and got push messages just fine!
